### PR TITLE
Add random string to temporary directory in solweig_algorithm.py

### DIFF
--- a/processor/solweig_algorithm.py
+++ b/processor/solweig_algorithm.py
@@ -69,6 +69,8 @@ from ..functions.SOLWEIGpython import PET_calculations as p
 from ..functions.SOLWEIGpython import UTCI_calculations as utci
 from ..functions.SOLWEIGpython.CirclePlotBar import PolarBarPlot
 import matplotlib.pyplot as plt
+import string
+import random
 
 # For "Save necessary rasters for TreePlanter tool"
 from shutil import copyfile
@@ -294,7 +296,8 @@ class ProcessingSOLWEIGAlgorithm(QgsProcessingAlgorithm):
                                                      'Output folder'))
 
         self.plugin_dir = os.path.dirname(__file__)
-        self.temp_dir = os.path.dirname(self.plugin_dir) + '/temp'
+        temp_dir_name = 'temp-' + ''.join(random.choice(string.ascii_uppercase) for _ in range(8))
+        self.temp_dir = os.path.join(os.path.dirname(self.plugin_dir), temp_dir_name)
 
     def processAlgorithm(self, parameters, context, feedback):
         np.seterr(divide='ignore', invalid='ignore')


### PR DESCRIPTION
This commit adds a random string to the temporary directory `self.temp_dir` in solweig_algorithm.py. The goal is to make this directory unique. This matters when parallelizing solweig in a HPC environment. In this context multiple instances of solweig might run on the same compute node all trying to use the same temporary directory, which causes some instances to fail.