### PR TITLE
Remove temporary directory for SVFs

### DIFF
--- a/processor/solweig_algorithm.py
+++ b/processor/solweig_algorithm.py
@@ -69,6 +69,7 @@ from ..functions.SOLWEIGpython import PET_calculations as p
 from ..functions.SOLWEIGpython import UTCI_calculations as utci
 from ..functions.SOLWEIGpython.CirclePlotBar import PolarBarPlot
 import matplotlib.pyplot as plt
+from shutil import copyfile, rmtree
 import string
 import random
 
@@ -1248,6 +1249,8 @@ class ProcessingSOLWEIGAlgorithm(QgsProcessingAlgorithm):
         saveraster(gdal_dsm, outputDir + '/Tmrt_average.tif', tmrtplot)
         feedback.setProgressText("SOLWEIG: Model calculation finished.")
 
+        rmtree(self.temp_dir, ignore_errors=True)  
+     
         return {self.OUTPUT_DIR: outputDir}
     
     def name(self):


### PR DESCRIPTION
Sorry but my previous PR requires another change: deleting the temporary folder. Otherwise, the user ends up with dozens or hundreds of temporary folders. Previously, the files were just overwritten because SOLWEIG always used the same locations (which was problematic when multiple instances run at the same time).