### PR TITLE
Fix calculation of poisxy

### DIFF
--- a/processor/solweig_algorithm.py
+++ b/processor/solweig_algorithm.py
@@ -743,11 +743,11 @@ class ProcessingSOLWEIGAlgorithm(QgsProcessingAlgorithm):
 
                 poiname.append(f.attributes()[idx])
                 poisxy[ind, 0] = ind
-                poisxy[ind, 1] = np.round((x - minx) * scale)
+                poisxy[ind, 1] = np.ceil((x - minx) * scale) - 1
                 if miny >= 0:
-                    poisxy[ind, 2] = np.round((miny + rows * (1. / scale) - y) * scale)
+                    poisxy[ind, 2] = np.ceil((miny + rows * (1. / scale) - y) * scale) - 1
                 else:
-                    poisxy[ind, 2] = np.round((miny + rows * (1. / scale) - y) * scale)
+                    poisxy[ind, 2] = np.ceil((miny + rows * (1. / scale) - y) * scale) - 1
 
                 ind += 1
 


### PR DESCRIPTION
I think the `poisxy` is not calculated correctly in `solweig_algorithm.py` and is off by 1 in many cases in both the x and y dimension. As a result, the POI calculation uses the wrong cell for the `tmrt` value and other things are probably off as well.

Currently, the cell number in the x-dimension is calculated like this:

```
np.round((x - minx) * scale)
```

However, the rounding leads to wrong cell numbers in some situations.

Take the following raster:

- dimensions  : 3, 3, 1  (nrow, ncol, nlyr)
- resolution  : 2, 2  (x, y)
- extent      : 0, 6, 0, 6  (xmin, xmax, ymin, ymax)

And a point right in the middle at `x = 3`, `y = 3`, which should be in cell 1, 1. However, solweig gets
the wrong point:

```
x = 3
minx = 0
scale = 1/2
np.round((x - minx) * scale)
```

This pull request instead uses the following code to calculate the point location and a similar logic
for the y-dimension.

```
np.ceil((x - minx) * scale) - 1
```