### PR TITLE
Avoid shadowing QGIS bundled Python packages

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,14 +22,12 @@
  This script initializes the plugin, making it known to QGIS.
 """
 
-# The .egg packages shipped with QGIS sometimes appear before the user site dir
-# in sys.path. To make sure package versions we install with "--user"
-# take precedence, # prepend the user site dir to sys.path before importing
-# other packages. # This works around https://github.com/qgis/QGIS/issues/55258
 import site
 import sys
 
-sys.path.insert(0, site.getusersitepackages())
+user_site = site.getusersitepackages()
+if user_site not in sys.path:
+    sys.path.append(user_site)
 
 __author__ = "Fredrik Lindberg"
 __date__ = "2020-04-02"


### PR DESCRIPTION
Title: Avoid shadowing QGIS bundled Python packages

## Summary

- Keep the user site-packages directory available for UMEP-processing dependencies such as `supy`.
- Append the user site-packages directory instead of prepending it, so QGIS's bundled/signed scientific packages remain preferred.

## Verification

- Ran `python3 -m py_compile UMEP-processing/__init__.py`.
- Reproduced locally that prepending the user site can make QGIS load unsigned local compiled wheels before bundled packages on macOS.

## Context

On macOS, QGIS ships signed Python packages such as `numpy`, `scipy`, and `matplotlib`. Putting `~/.local/lib/python3.12/site-packages` ahead of QGIS's bundled site-packages can make QGIS import local compiled wheels instead, which may fail code-signing/library-validation checks.
