### PR TITLE
Fix tqdm crash in TARGET (#116): route progress through QgsProcessingFeedback

### DIFF
--- a/processor/target_algorithm.py
+++ b/processor/target_algorithm.py
@@ -332,6 +332,7 @@ class ProcessingTargetProcessorAlgorithm(QgsProcessingAlgorithm):
             # passing the simulation's config file
             os.path.join(inputDir, "config.ini"),
             progress=True,  # show progress bars in console
+            feedback=feedback,  # route progress to the QGIS progress bar instead
         )
         tar.load_config()
 


### PR DESCRIPTION
Fixes #116.

`tqdm` writes its progress bar to `sys.stdout`, which QGIS sets to `None` when the Python console is not open, crashing with `AttributeError: 'NoneType' object has no attribute 'write'` (and the same for the `logging` calls in the same run).

`target-py` [0.2.0](https://pypi.org/project/target-py/0.2.0/) adds an optional `feedback` parameter to `Target(...)` that routes progress through a `QgsProcessingFeedback`/`QgsFeedback` object instead of `tqdm` when one is provided. This wires it through in `target_algorithm.py`.

**Requires `target-py>=0.2.0`.** Companion PR bumping the version pin in `umep-reqs`: UMEP-dev/umep-reqs#15

Tested locally on QGIS 3.40.5 (macOS) by running the TARGET algorithm through the actual Processing Toolbox GUI with `target-py` 0.2.0 installed.